### PR TITLE
Emit loader events on the `asapScheduler` to avoid expression changed

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,5 +1,5 @@
 <div class="app">
-  <!--  <pubg-loader *ngIf="loaderSub > 0"></pubg-loader>-->
   <!--  <p-confirmDialog header="Confirmation" icon="pi pi-exclamation-triangle"></p-confirmDialog>-->
+  <pubg-loader *ngIf="loaderSub$ | async"></pubg-loader>
   <router-outlet></router-outlet>
 </div>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,6 +1,7 @@
 import { LoaderService } from './shared/services/loader.service';
 import { Component } from '@angular/core';
-import { ConfirmationService } from 'primeng/api';
+import { Observable } from 'rxjs';
+import { map, tap } from 'rxjs/operators';
 
 @Component({
   selector: 'pubg-root',
@@ -8,15 +9,12 @@ import { ConfirmationService } from 'primeng/api';
   styleUrls: ['./app.component.scss']
 })
 export class AppComponent {
-  public loaderSub: number;
+  public loaderSub$: Observable<boolean>;
 
   constructor(private loaderSrv: LoaderService) {
-    this.loaderSub = 0;
-
-    this.loaderSrv.counterValue.subscribe(val => {
-      // console.log(val);
-
-      this.loaderSub = val;
-    });
+    this.loaderSub$ = this.loaderSrv.counterValue$.pipe(
+      tap(console.log),
+      map(r => r > 0)
+    );
   }
 }

--- a/src/app/shared/services/loader.service.ts
+++ b/src/app/shared/services/loader.service.ts
@@ -1,27 +1,37 @@
 import { Injectable } from '@angular/core';
-import { Subject, Observable, BehaviorSubject } from 'rxjs';
+import { Observable, BehaviorSubject, asapScheduler } from 'rxjs';
+import { debounceTime, distinctUntilChanged, observeOn } from 'rxjs/operators';
 
 @Injectable({
   providedIn: 'root'
 })
 export class LoaderService {
+  private counterSubject: BehaviorSubject<number>;
+
   // private loadCounter: number;
   public loadCounter: number;
-  public counterValue: BehaviorSubject<number>;
+  public counterValue$: Observable<number>;
   // public handlerWithoutDelay: Subject<any> = new Subject();
 
   constructor() {
+    const LOADER_EVENTS_DEBOUNCE = 50;
+
     this.loadCounter = 0;
-    this.counterValue = new BehaviorSubject<number>(this.loadCounter);
+    this.counterSubject = new BehaviorSubject<number>(this.loadCounter);
+    this.counterValue$ = this.counterSubject.pipe(
+      debounceTime(LOADER_EVENTS_DEBOUNCE),
+      distinctUntilChanged(),
+      observeOn(asapScheduler)
+    );
   }
 
   public increaseCounter(): void {
     this.loadCounter += 1;
-    this.counterValue.next(this.loadCounter);
+    this.counterSubject.next(this.loadCounter);
   }
 
   public decreaseCounter(): void {
     this.loadCounter -= 1;
-    this.counterValue.next(this.loadCounter);
+    this.counterSubject.next(this.loadCounter);
   }
 }


### PR DESCRIPTION
  after it has been checked errors.