### PR TITLE
Typo bug - missing closing parenthesis on `map` call

### DIFF
--- a/src/app/store/effects/user.effects.ts
+++ b/src/app/store/effects/user.effects.ts
@@ -45,10 +45,8 @@ export class UserEffects {
       ofType(fromUsersActions.loadUser),
       mergeMap(action =>
         this.apiService.loadUser(action.user).pipe(
-          map(
-            user => fromUsersActions.loadUserSuccess({ user }),
-            catchError(error => of(fromUsersActions.loadUserFailure({ error })))
-          )
+          map(user => fromUsersActions.loadUserSuccess({ user })),
+          catchError(error => of(fromUsersActions.loadUserFailure({ error })))
         )
       )
     )


### PR DESCRIPTION
How do I push little bug fixes like this?